### PR TITLE
Reduce attack surface for Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,68 +1,9 @@
-.git
-Dockerfile
+**
 
-.idea
-startenv
-
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*,cover
-.hypothesis/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-#Ipython Notebook
-.ipynb_checkpoints
+!src/
+!requirements.txt
+!LICENSE
+!README.md
+!MANIFEST.in
+!setup.py
+!tox.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.1-alpine3.15
+FROM python:3.11.4-alpine3.18
 ADD . /usr/src/hpilo_exporter
 
 # Install psutil - needs linux-headers and build-base with gcc, remove it afterwards by name '.build-steps'. Install exporter.
@@ -8,7 +8,7 @@ ENTRYPOINT ["hpilo-exporter"]
 EXPOSE 9416
 
 # These warnings can be ignored:
-# WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. 
+# WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager.
 # It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
 # WARNING: You are using pip version 21.2.4; however, version 21.3.1 is available.
 # You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.


### PR DESCRIPTION
The current `.dockerignore` file is designed as deny-list. Representing an allow-list reduced the overall amount of files that are sent to the Docker build daemon and allows for easier and more fine-grained specification of the copied files.

In example, `alerts.hpilo.yml`, the `grafana_dashboard.json` and the whole `.github` folder shouldn't be part of the resulting image. This is currently the case.

Additionally, the Docker base image is now up-to-date.