### PR TITLE
fix: ILO5 reporting battery module as 'Not installed' instead of 'Absent'

### DIFF
--- a/src/hpilo_exporter/exporter.py
+++ b/src/hpilo_exporter/exporter.py
@@ -29,7 +29,7 @@ def translate(st):
         return 0
     elif st.upper() == 'DEGRADED':
         return 1
-    elif st.upper() == 'ABSENT':
+    elif st.upper() in ['ABSENT', 'NOT INSTALLED']:
         return -1
     else:
         return 2


### PR DESCRIPTION
Hello hpilo-exporter team,

I have an HP Ilo5 reporting a battery module as 'Not installed' which triggers a false alarm because hpilo_battery_status metric give a 2.0 value.

I suggest handling the 'Not installed' status as the 'Absent' one.

Regards,
Rodolphe Guillard.
